### PR TITLE
Add IE Config for NUM_BUILD_THREADS

### DIFF
--- a/inference-engine/include/cldnn/cldnn_config.hpp
+++ b/inference-engine/include/cldnn/cldnn_config.hpp
@@ -72,6 +72,11 @@ DECLARE_CLDNN_CONFIG_KEY(ENABLE_FP16_FOR_QUANTIZED_MODELS);
 */
 DECLARE_CLDNN_CONFIG_KEY(NV12_TWO_INPUTS);
 
+/**
+* @brief This key sets the number of threads used to build program.
+* 2 is a default value.
+*/
+DECLARE_CLDNN_CONFIG_KEY(N_OPENCL_BUILD_THREADS);
 
 }  // namespace CLDNNConfigParams
 }  // namespace InferenceEngine

--- a/inference-engine/include/cldnn/cldnn_config.hpp
+++ b/inference-engine/include/cldnn/cldnn_config.hpp
@@ -76,7 +76,7 @@ DECLARE_CLDNN_CONFIG_KEY(NV12_TWO_INPUTS);
 * @brief This key sets the number of threads used to build program.
 * 2 is a default value.
 */
-DECLARE_CLDNN_CONFIG_KEY(N_OPENCL_BUILD_THREADS);
+DECLARE_CLDNN_CONFIG_KEY(MAX_NUM_THREADS);
 
 }  // namespace CLDNNConfigParams
 }  // namespace InferenceEngine

--- a/inference-engine/src/cldnn_engine/cldnn_config.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_config.cpp
@@ -232,8 +232,9 @@ void Config::UpdateFromMap(const std::map<std::string, std::string>& configMap) 
                     n_threads = val_i;
                 }
             } catch (const std::exception&) {
-                THROW_IE_EXCEPTION << "Wrong value for property key " << CLDNNConfigParams::KEY_CLDNN_MAX_NUM_THREADS
-                                    << ". Expected only integer";
+                THROW_IE_EXCEPTION << "Wrong value for property key " << CLDNNConfigParams::KEY_CLDNN_MAX_NUM_THREADS << ": " << val
+                                   << "\nSpecify the number of threads use for build as an integer."
+                                   << "\nOut of range value will be set as a default value, maximum concurrent threads.";
             }
         } else {
             THROW_IE_EXCEPTION_WITH_STATUS(NotFound) << "Unsupported property key by plugin: " << key;

--- a/inference-engine/src/cldnn_engine/cldnn_config.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_config.cpp
@@ -222,7 +222,7 @@ void Config::UpdateFromMap(const std::map<std::string, std::string>& configMap) 
             } else {
                 THROW_IE_EXCEPTION_WITH_STATUS(NotFound) << "Unsupported KEY_CLDNN_ENABLE_FP16_FOR_QUANTIZED_MODELS flag value: " << val;
             }
-        } else if (key.compare(CLDNNConfigParams::KEY_CLDNN_N_OPENCL_BUILD_THREADS) == 0) {
+        } else if (key.compare(CLDNNConfigParams::KEY_CLDNN_MAX_NUM_THREADS) == 0) {
             int max_threads = std::thread::hardware_concurrency();
             try {
                 int val_i = std::stoi(val);
@@ -232,8 +232,8 @@ void Config::UpdateFromMap(const std::map<std::string, std::string>& configMap) 
                     n_threads = val_i;
                 }
             } catch (const std::exception&) {
-                THROW_IE_EXCEPTION << "Wrong value for property key " << CLDNNConfigParams::KEY_CLDNN_N_OPENCL_BUILD_THREADS
-                                    << "CLDNNConfigParams::KEY_CLDNN_N_OPENCL_BUILD_THREADS";
+                THROW_IE_EXCEPTION << "Wrong value for property key " << CLDNNConfigParams::KEY_CLDNN_MAX_NUM_THREADS
+                                    << ". Expected only integer";
             }
         } else {
             THROW_IE_EXCEPTION_WITH_STATUS(NotFound) << "Unsupported property key by plugin: " << key;
@@ -320,6 +320,6 @@ void Config::adjustKeyMapValues() {
     key_config_map[PluginConfigParams::KEY_GPU_THROUGHPUT_STREAMS] = std::to_string(throughput_streams);
     key_config_map[PluginConfigParams::KEY_DEVICE_ID] = device_id;
     key_config_map[PluginConfigParams::KEY_CONFIG_FILE] = "";
-    key_config_map[CLDNNConfigParams::KEY_CLDNN_N_OPENCL_BUILD_THREADS] = std::to_string(n_threads);
+    key_config_map[CLDNNConfigParams::KEY_CLDNN_MAX_NUM_THREADS] = std::to_string(n_threads);
 }
 }  // namespace CLDNNPlugin

--- a/inference-engine/src/cldnn_engine/cldnn_config.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_config.cpp
@@ -11,6 +11,7 @@
 #include "ie_api.h"
 #include "file_utils.h"
 #include "cldnn_itt.h"
+#include <thread>
 
 #ifdef _WIN32
 # include <direct.h>
@@ -221,6 +222,19 @@ void Config::UpdateFromMap(const std::map<std::string, std::string>& configMap) 
             } else {
                 THROW_IE_EXCEPTION_WITH_STATUS(NotFound) << "Unsupported KEY_CLDNN_ENABLE_FP16_FOR_QUANTIZED_MODELS flag value: " << val;
             }
+        } else if (key.compare(CLDNNConfigParams::KEY_CLDNN_N_OPENCL_BUILD_THREADS) == 0) {
+            int max_threads = std::thread::hardware_concurrency();
+            try {
+                int val_i = std::stoi(val);
+                if (val_i <= 0 || val_i > max_threads) {
+                    n_threads = max_threads;
+                } else {
+                    n_threads = val_i;
+                }
+            } catch (const std::exception&) {
+                THROW_IE_EXCEPTION << "Wrong value for property key " << CLDNNConfigParams::KEY_CLDNN_N_OPENCL_BUILD_THREADS
+                                    << "CLDNNConfigParams::KEY_CLDNN_N_OPENCL_BUILD_THREADS";
+            }
         } else {
             THROW_IE_EXCEPTION_WITH_STATUS(NotFound) << "Unsupported property key by plugin: " << key;
         }
@@ -306,5 +320,6 @@ void Config::adjustKeyMapValues() {
     key_config_map[PluginConfigParams::KEY_GPU_THROUGHPUT_STREAMS] = std::to_string(throughput_streams);
     key_config_map[PluginConfigParams::KEY_DEVICE_ID] = device_id;
     key_config_map[PluginConfigParams::KEY_CONFIG_FILE] = "";
+    key_config_map[CLDNNConfigParams::KEY_CLDNN_N_OPENCL_BUILD_THREADS] = std::to_string(n_threads);
 }
 }  // namespace CLDNNPlugin

--- a/inference-engine/src/cldnn_engine/cldnn_config.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_config.cpp
@@ -223,7 +223,7 @@ void Config::UpdateFromMap(const std::map<std::string, std::string>& configMap) 
                 THROW_IE_EXCEPTION_WITH_STATUS(NotFound) << "Unsupported KEY_CLDNN_ENABLE_FP16_FOR_QUANTIZED_MODELS flag value: " << val;
             }
         } else if (key.compare(CLDNNConfigParams::KEY_CLDNN_MAX_NUM_THREADS) == 0) {
-            int max_threads = std::thread::hardware_concurrency();
+            int max_threads = (std::thread::hardware_concurrency() == 0) ? 1 : std::thread::hardware_concurrency();
             try {
                 int val_i = std::stoi(val);
                 if (val_i <= 0 || val_i > max_threads) {

--- a/inference-engine/src/cldnn_engine/cldnn_config.h
+++ b/inference-engine/src/cldnn_engine/cldnn_config.h
@@ -32,7 +32,7 @@ struct Config {
                sources_dumps_dir(""),
                device_id(""),
                kernels_cache_dir(""),
-               n_threads(std::thread::hardware_concurrency()) {
+               n_threads((std::thread::hardware_concurrency() == 0) ? 1 : std::thread::hardware_concurrency()) {
         adjustKeyMapValues();
     }
 

--- a/inference-engine/src/cldnn_engine/cldnn_config.h
+++ b/inference-engine/src/cldnn_engine/cldnn_config.h
@@ -32,7 +32,7 @@ struct Config {
                sources_dumps_dir(""),
                device_id(""),
                kernels_cache_dir(""),
-               n_threads(2) {
+               n_threads(std::thread::hardware_concurrency()) {
         adjustKeyMapValues();
     }
 

--- a/inference-engine/src/cldnn_engine/cldnn_config.h
+++ b/inference-engine/src/cldnn_engine/cldnn_config.h
@@ -31,7 +31,8 @@ struct Config {
                graph_dumps_dir(""),
                sources_dumps_dir(""),
                device_id(""),
-               kernels_cache_dir("") {
+               kernels_cache_dir(""),
+               n_threads(2) {
         adjustKeyMapValues();
     }
 
@@ -56,6 +57,7 @@ struct Config {
     std::string sources_dumps_dir;
     std::string device_id;
     std::string kernels_cache_dir;
+    int n_threads;
 
     std::map<std::string, std::string> key_config_map;
 };

--- a/inference-engine/src/cldnn_engine/cldnn_engine.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_engine.cpp
@@ -461,7 +461,8 @@ ExecutableNetworkInternal::Ptr clDNNEngine::LoadExeNetworkImpl(const InferenceEn
                context_config.tuningConfig.mode == current_config.tuningConfig.mode &&
                context_config.tuningConfig.cache_file_path == current_config.tuningConfig.cache_file_path &&
                context_config.kernels_cache_dir == current_config.kernels_cache_dir &&
-               context_config.device_id == current_config.device_id;
+               context_config.device_id == current_config.device_id &&
+               context_config.n_threads == current_config.n_threads;
     };
 
     {

--- a/inference-engine/src/cldnn_engine/cldnn_remote_context.cpp
+++ b/inference-engine/src/cldnn_engine/cldnn_remote_context.cpp
@@ -267,7 +267,8 @@ CLDNNExecutionContextImpl::CLDNNExecutionContextImpl(const std::shared_ptr<IInfe
                 m_config.queueThrottle,
                 m_config.memory_pool_on,
                 m_config.throughput_streams,
-                m_config.kernels_cache_dir));
+                m_config.kernels_cache_dir,
+                m_config.n_threads));
     }
 }
 

--- a/inference-engine/thirdparty/clDNN/api/cldnn.hpp
+++ b/inference-engine/thirdparty/clDNN/api/cldnn.hpp
@@ -135,6 +135,7 @@
 #include <memory>
 #include <string>
 #include <type_traits>
+#include <thread>
 
 namespace cldnn {
 

--- a/inference-engine/thirdparty/clDNN/api/engine.hpp
+++ b/inference-engine/thirdparty/clDNN/api/engine.hpp
@@ -96,7 +96,7 @@ struct engine_configuration {
         bool memory_pool = true,
         uint16_t n_streams = 1,
         const std::string& kernels_cache_path = "",
-        int n_threads = std::thread::hardware_concurrency(),
+        int n_threads = (std::thread::hardware_concurrency() == 0) ? 1 : std::thread::hardware_concurrency(),
         const std::string& tuning_cache_path = "cache.json")
         : enable_profiling(profiling)
         , meaningful_kernels_names(decorate_kernel_names)

--- a/inference-engine/thirdparty/clDNN/api/engine.hpp
+++ b/inference-engine/thirdparty/clDNN/api/engine.hpp
@@ -73,6 +73,7 @@ struct engine_configuration {
                                               ///< (switched off for older drivers then NEO).
     uint16_t n_streams;                       ///< Number of queues executed in parallel
     const std::string kernels_cache_path;     ///< Path to compiled kernels cache
+    int n_threads; ///< Number of threads used to build program
     const std::string tuning_cache_path;      ///< Path to tuning kernel cache
 
     /// @brief Constructs engine configuration with specified options.
@@ -95,6 +96,7 @@ struct engine_configuration {
         bool memory_pool = true,
         uint16_t n_streams = 1,
         const std::string& kernels_cache_path = "",
+        int n_threads = 2,
         const std::string& tuning_cache_path = "cache.json")
         : enable_profiling(profiling)
         , meaningful_kernels_names(decorate_kernel_names)
@@ -109,6 +111,7 @@ struct engine_configuration {
         , enable_memory_pool(memory_pool)
         , n_streams(n_streams)
         , kernels_cache_path(kernels_cache_path)
+        , n_threads(n_threads)
         , tuning_cache_path(tuning_cache_path) {
         if (n_streams == 0) {
             throw std::invalid_argument("Invalid streams count set in engine config");

--- a/inference-engine/thirdparty/clDNN/api/engine.hpp
+++ b/inference-engine/thirdparty/clDNN/api/engine.hpp
@@ -96,7 +96,7 @@ struct engine_configuration {
         bool memory_pool = true,
         uint16_t n_streams = 1,
         const std::string& kernels_cache_path = "",
-        int n_threads = 2,
+        int n_threads = std::thread::hardware_concurrency(),
         const std::string& tuning_cache_path = "cache.json")
         : enable_profiling(profiling)
         , meaningful_kernels_names(decorate_kernel_names)

--- a/inference-engine/thirdparty/clDNN/src/engine.cpp
+++ b/inference-engine/thirdparty/clDNN/src/engine.cpp
@@ -95,6 +95,7 @@ gpu_toolkit_config convert_configuration(const engine_configuration conf) {
     result.queues_num = conf.n_streams;
     result.kernels_cache_path = conf.kernels_cache_path;
     result.tuning_cache_path = conf.tuning_cache_path;
+    result.n_threads = conf.n_threads;
     return result;
 }
 

--- a/inference-engine/thirdparty/clDNN/src/gpu/configuration.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/configuration.cpp
@@ -35,6 +35,6 @@ configuration::configuration()
       queues_num(0),
       tuning_cache_path("cache.json"),
       kernels_cache_path(""),
-      n_threads(std::thread::hardware_concurrency()) {}
+      n_threads((std::thread::hardware_concurrency() == 0) ? 1 : std::thread::hardware_concurrency()) {}
 }  // namespace gpu
 }  // namespace cldnn

--- a/inference-engine/thirdparty/clDNN/src/gpu/configuration.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/configuration.cpp
@@ -34,6 +34,7 @@ configuration::configuration()
       throttle_mode(throttle_mode_types::disabled),
       queues_num(0),
       tuning_cache_path("cache.json"),
-      kernels_cache_path("") {}
+      kernels_cache_path(""),
+      n_threads(2) {}
 }  // namespace gpu
 }  // namespace cldnn

--- a/inference-engine/thirdparty/clDNN/src/gpu/configuration.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/configuration.cpp
@@ -35,6 +35,6 @@ configuration::configuration()
       queues_num(0),
       tuning_cache_path("cache.json"),
       kernels_cache_path(""),
-      n_threads(2) {}
+      n_threads(std::thread::hardware_concurrency()) {}
 }  // namespace gpu
 }  // namespace cldnn

--- a/inference-engine/thirdparty/clDNN/src/gpu/configuration.h
+++ b/inference-engine/thirdparty/clDNN/src/gpu/configuration.h
@@ -43,6 +43,7 @@ struct configuration {
     uint16_t queues_num;
     std::string tuning_cache_path;
     std::string kernels_cache_path;
+    uint16_t n_threads;
 };
 }  // namespace gpu
 }  // namespace cldnn

--- a/inference-engine/thirdparty/clDNN/src/gpu/kernels_cache.cpp
+++ b/inference-engine/thirdparty/clDNN/src/gpu/kernels_cache.cpp
@@ -293,11 +293,12 @@ void kernels_cache::get_program_source(const kernels_code& kernels_source_code, 
 }
 
 kernels_cache::kernels_cache(gpu_toolkit& context, uint32_t prog_id) : _context(context), _prog_id(prog_id) {
+    int n_threads = _context.get_configuration().n_threads;
 #if (CLDNN_OCL_BUILD_THREADING == CLDNN_OCL_BUILD_THREADING_TBB)
     arena = std::unique_ptr<tbb::task_arena>(new tbb::task_arena());
-    arena->initialize(DEFAULT_NUM_THREADS);
+    arena->initialize(n_threads);
 #elif(CLDNN_OCL_BUILD_THREADING == CLDNN_OCL_BUILD_THREADING_THREADPOOL)
-    pool = std::unique_ptr<thread_pool>(new thread_pool(DEFAULT_NUM_THREADS));
+    pool = std::unique_ptr<thread_pool>(new thread_pool(n_threads));
 #endif
 }
 


### PR DESCRIPTION
### Details:
 - Add a new IE config key, KEY_CLDNN_MAX_NUM_THREADS, which sets the number of threads used to build program.
 - Default value is maximum concurrency 

### Tickets: