### PR TITLE
Fix exception failure on top_k_layer_test.second_output_taylor

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/permute.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/permute.hpp
@@ -35,7 +35,7 @@ struct permute : public primitive_base<permute> {
             const std::vector<uint16_t>& permute_order = {},
             const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, {output_padding}, {}),  permute_order(permute_order) {}
+        : primitive_base(id, {input}, ext_prim_id, {output_padding}), permute_order(permute_order) {}
 
     /// @brief Array of permuted output order in bfyx format.
     std::vector<uint16_t> permute_order;

--- a/src/plugins/intel_gpu/src/graph/input_layout.cpp
+++ b/src/plugins/intel_gpu/src/graph/input_layout.cpp
@@ -46,7 +46,7 @@ void input_layout_inst::set_data(memory::ptr mem) {
     check_memory_to_set(*mem, ol);
 
     if (mem->is_allocated_by(get_network().get_engine())) {
-        _outputs.push_back(mem);
+        _outputs = {mem};
     } else {
         mem_lock<char, mem_lock_type::read> src(mem, get_network().get_stream());
         mem_lock<char, mem_lock_type::write> dst(_outputs[0], get_network().get_stream());


### PR DESCRIPTION
### Details:
 - remove empty output_data_types initialization during creating permute
 - fix output memory of input_layout to be set normally

### Tickets:
 - *ticket-id*
